### PR TITLE
Studio 3.0 support

### DIFF
--- a/src/Android/SleepAnalyzer/app/build.gradle
+++ b/src/Android/SleepAnalyzer/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.tssg.sleepanalyzer"

--- a/src/Android/SleepAnalyzer/build.gradle
+++ b/src/Android/SleepAnalyzer/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 

--- a/src/Android/SleepAnalyzer/gradle/wrapper/gradle-wrapper.properties
+++ b/src/Android/SleepAnalyzer/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 27 12:45:01 EST 2016
+#Tue Nov 21 14:28:50 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2-bin.zip


### PR DESCRIPTION
build.gradle - upgraded to gradle plugin version 3.0.1
app/build.gradle - removed unnecessary "buildToolsVersion"
gradle/wrapper/gradle-wrapper.properties - upgraded to runtime version gradle-4.2-bin.zip
