### PR TITLE
Android Studio 3.1

### DIFF
--- a/src/Android/SleepAnalyzer/app/build.gradle
+++ b/src/Android/SleepAnalyzer/app/build.gradle
@@ -22,6 +22,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:25.3.1'
-    compile files('libs/libmuse_android.jar')
+    implementation 'com.android.support:support-v4:25.3.1'
+    implementation files('libs/libmuse_android.jar')
 }

--- a/src/Android/SleepAnalyzer/build.gradle
+++ b/src/Android/SleepAnalyzer/build.gradle
@@ -2,14 +2,16 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/src/Android/SleepAnalyzer/gradle/wrapper/gradle-wrapper.properties
+++ b/src/Android/SleepAnalyzer/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 21 14:28:50 EST 2017
+#Tue Mar 27 11:57:27 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip


### PR DESCRIPTION

Updated for Android Studio 3.1:
------------------------------------

/gradle.build

     added 'google()' repository
     gradle:3.0.1 changed to gradle:3.1.0

app/build.gradle

     'compile' keyword deprecated - changed to 'implementation'

gradle/wrapper/gradle-wrapper.properties

     gradle-42-bin.zip changed to gradle-4.4-bin.zip

