### PR TITLE
Studio 3.1.3 update

### DIFF
--- a/src/Android/SleepAnalyzer/build.gradle
+++ b/src/Android/SleepAnalyzer/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
 


### PR DESCRIPTION
This is an update to support Studio version 3.1.3

build.gradle:

     classpath 'com.android.tools.build:gradle:3.1.2' changed to classpath 'com.android.tools.build:gradle:3.1.3'