### PR TITLE
Update for Studio 3.1.4

### DIFF
--- a/src/Android/SleepAnalyzer/build.gradle
+++ b/src/Android/SleepAnalyzer/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 


### PR DESCRIPTION

/build.gradle

     changed classpath 'com.android.tools.build:gradle:3.1.4' to classpath 'com.android.tools.build:gradle:3.1.5'